### PR TITLE
Require date in the changelog generator

### DIFF
--- a/generate-jenkins-changelog.rb
+++ b/generate-jenkins-changelog.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require 'date'
 require 'yaml'
 require 'json'
 


### PR DESCRIPTION
Needed on Ubuntu 18.04 with default ruby installation